### PR TITLE
chore: prepare release v1.5.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,7 +1471,7 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "localdesktop"
-version = "1.5.13"
+version = "1.5.17"
 dependencies = [
  "android-sdkmanager-rs",
  "android_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "localdesktop"
-version = "1.5.13"
+version = "1.5.17"
 edition = "2021"
 build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Release branch for `v1.5.17`.

## Included changes

<!-- release-source-pr:239 -->
### #239 [codex] Rework release automation

## Summary
- replace the hidden tag-only version bump flow with a dedicated `ci/release` PR flow
- update both `Cargo.toml` and `Cargo.lock` on the release branch so `main` carries the real app version
- tag `main` only after the release PR merges, and let the tag-triggered build publish the release
- keep release notes on annotated tags and read them from the GitHub API during the build job
- remove stale workflow behavior that existed only to support manual build dispatch from synthetic release commits

## Why
The previous release automation created a commit object only for the tag, without putting the version bump onto `main`. That left `Cargo.toml` and `Cargo.lock` stale on `main`, while release artifacts were built from a hidden CI-only commit. It also made release notes fragile, because the build job could fall back to the synthetic `chore: prepare release ...` commit message.

The repository ruleset requires `main` changes to go through a pull request, so the version bump needs to follow the same path instead of bypassing normal history.

## Impact
- feature PRs still require exactly one release label
- gh-pages-only PRs stay exempt from release bumps
- merged feature PRs now create or update a dedicated release PR on `ci/release`
- merging that release PR tags `main`, and the existing tag-based build/release flow publishes the artifacts
- release notes come from the release PR body/tag annotation instead of the synthetic bump commit

## Validation
- parsed `.github/workflows/auto-bump-version.yml` and `.github/workflows/build.yml` as YAML
- ran `git diff --check`

I did not run the full GitHub Actions flow end to end from this branch.
