### PR TITLE
chore: prepare release v1.5.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,7 +1471,7 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "localdesktop"
-version = "1.5.17"
+version = "1.5.18"
 dependencies = [
  "android-sdkmanager-rs",
  "android_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "localdesktop"
-version = "1.5.17"
+version = "1.5.18"
 edition = "2021"
 build = "build.rs"
 default-run = "build_apk"


### PR DESCRIPTION
Release branch for `v1.5.18`.

## Included changes

<!-- release-source-pr:228 -->
### #228 feat: build the APK directly from Termux on Android

# feat: build the APK directly from Termux on Android

Just for fun — turns out you can build the APK directly from Termux on an Android device (ARM64) without needing a separate machine. Not something most people will need, but it works!

xbuild patches (compile-time guarded with `cfg!(target_os = "android")`, no effect on other platforms):
- **Platform detection**: Android reports `target_os = "android"`, not `"linux"`. Add it to the Linux branch so xbuild recognises Termux as a Linux host.
- **Native aapt2**: AGP bundles an x86_64 aapt2 that can't run on ARM64. Inject `android.aapt2FromMavenOverride` in `gradle.properties` pointing to the native ARM64 aapt2 from Termux (`pkg install aapt2`).

Also adds:
- `scripts/build-termux.sh`: idempotent one-shot build script. Uses `MALLOC_TAG_LEVEL=0` to prevent LLVM/lld from crashing due to Android pointer tagging.
- `src/bin/download_sdk.rs`: downloads `build-tools;34.0.0` since the SDK manager bundled with xbuild doesn't run on ARM64.

Note: this is separate from `feat/termux-patched-proot` (already merged) which switched to Termux's patched proot binary — that's about *running* proot on Android, while this is about *building* the APK from Android.

Also depends on `fix/gradle9-compat` (or just include that change here if merged together).
