### PR TITLE
[codex] update AdSense publisher ID

### DIFF
--- a/gh-pages/src/theme/Layout/index.tsx
+++ b/gh-pages/src/theme/Layout/index.tsx
@@ -24,7 +24,7 @@ export default function LayoutWrapper(props: Props): ReactNode {
       {!noAdsense && (
         <Head>
           <script
-            src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4231427019106835"
+            src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-8496762857844623"
             type="text/javascript"
             crossOrigin="anonymous"
             async

--- a/gh-pages/static/ads.txt
+++ b/gh-pages/static/ads.txt
@@ -1,1 +1,1 @@
-google.com, pub-4231427019106835, DIRECT, f08c47fec0942fa0
+google.com, pub-8496762857844623, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## What changed
- updated the existing AdSense script injection in the Docusaurus layout to use `ca-pub-8496762857844623`
- updated `gh-pages/static/ads.txt` to the matching publisher entry

## Why
The site was still configured with the previous AdSense publisher ID. This switches the current integration over to the new account without changing the integration method.

## Impact
Pages that already load the AdSense script through the shared layout will now register against the new publisher account, and the published `ads.txt` will match that account.

## Validation
- `pnpm build` in `gh-pages`
