### PR TITLE
chore: prepare release v1.5.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,7 +1471,7 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "localdesktop"
-version = "1.5.17"
+version = "1.5.18"
 dependencies = [
  "android-sdkmanager-rs",
  "android_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "localdesktop"
-version = "1.5.17"
+version = "1.5.18"
 edition = "2021"
 build = "build.rs"
 default-run = "build_apk"


### PR DESCRIPTION
Release branch for `v1.5.18`.

## Included changes

<!-- release-source-pr:244 -->
### #244 feat(termux): integrate xbuild pipeline into cargo run

Builds on #228 to make `cargo run` the single entry point for building on Termux — no manual setup required.

- **Auto-install xbuild** from `patches/xbuild/xbuild` if not present, then builds the APK.
- **Pre-download SDK components** (`build-tools;34.0.0` + `platforms;android-{target_sdk}`) via the pure-Rust `android_sdkmanager` crate (ARM64-compatible). Target SDK version is read dynamically from `manifest.yaml`, no hardcoded API levels.
- **Write `local.properties`** (`sdk.dir`) and SDK license files into the xbuild Gradle setup, so AGP can locate the SDK on first/clean builds without the x86_64-only `sdkmanager`.
- **Resolve xbuild by absolute path** (`~/.cargo/bin/x`) so it is found even when `~/.cargo/bin` is not in the subprocess PATH, which is common in Termux.
- **Remove `download_sdk` binary** — its logic is now handled automatically inside `try_xbuild()`.
- **Update README** — correct `pkg install` dependencies, document `cargo run` vs `build-termux.sh` (script stays useful for faster iteration: avoids the double compilation).

A second self-contained commit adds a **hint on license hash mismatch**: if the build fails because AGP doesn't accept the bundled SHA-1 hashes, a message points to the `ANDROID_SDK_LICENSE` / `ANDROID_SDK_PREVIEW_LICENSE` env vars that override them without a code change. This commit can be dropped independently if preferred.

## Test plan

Tested from clean state (no SDK cache, no build artifacts) on Honor Magic V2 (ARM64, Termux):

- `cargo run` — first run, xbuild absent → auto-installs xbuild, downloads SDK, BUILD SUCCESSFUL
- `cargo run` — clean SDK, xbuild present → downloads SDK, BUILD SUCCESSFUL
- `ANDROID_SDK_LICENSE=baadhash cargo run` — BUILD FAILED + hint displayed
- `cargo run` (subsequent) — incremental, fast
