### PR TITLE
[codex] Add experimental Turnip graphics config

### DIFF
--- a/gh-pages/docs/user/4-configurations.md
+++ b/gh-pages/docs/user/4-configurations.md
@@ -24,6 +24,23 @@ Some important notes:
 
 We might draw a table or have a mechanism to generate the config schema automatically here. But for now, please check the code for the schema: [localdesktop/src/utils/config.rs#L32-L88](https://github.com/localdesktop/localdesktop.github.io/blob/a581c45943fcfd97d1292ed1847f5a1556de4632/src/utils/config.rs#L32-L88).
 
+### Experimental Turnip / Mesa config
+
+Local Desktop can pass a user-provided Mesa Turnip Vulkan ICD into the Linux session. This is an advanced opt-in setting for users who already have a compatible Turnip/Mesa build inside the Arch filesystem.
+
+```toml title="/etc/localdesktop/localdesktop.toml"
+[graphics]
+turnip_path = "/usr/share/vulkan/icd.d/freedreno_icd.aarch64.json"
+turnip_library_path = "/usr/lib"
+turnip_use_zink = false
+```
+
+- `turnip_path` is the path to the Vulkan ICD JSON inside the Linux filesystem. Local Desktop exports it as both `VK_ICD_FILENAMES` and `VK_DRIVER_FILES`.
+- `turnip_library_path` is optional. Use it when the ICD JSON points at driver libraries outside the normal Linux linker paths.
+- `turnip_use_zink` is optional and disabled by default. When enabled, Local Desktop asks Mesa to run OpenGL through Zink on top of Vulkan by exporting `MESA_LOADER_DRIVER_OVERRIDE=zink` and `GALLIUM_DRIVER=zink`.
+
+These settings do not bundle a GPU driver or replace Local Desktop's Android EGL renderer. They only make it easier to test compatible Turnip/Mesa builds from inside the Linux desktop session.
+
 ## Special `try_*` configs
 
 Some configs are so important that a misconfiguration can leave you stuck on a black screen. So we support a special `try_*` variant of each config. These configs have **higher priority**, but only get applied **once**.

--- a/src/android/proot/launch.rs
+++ b/src/android/proot/launch.rs
@@ -30,22 +30,26 @@ pub fn launch() {
         ArchProcess {
             command: "rm -f /tmp/.X1-lock".into(),
             user: None,
+            env: vec![],
             log: None,
         }
         .run();
         ArchProcess {
             command: "rm -f /tmp/.X11-unix/X1".into(),
             user: None,
+            env: vec![],
             log: None,
         }
         .run();
 
         let local_config = get_application_context().local_config;
         let username = local_config.user.username;
+        let graphics_env = local_config.graphics.env_vars();
 
         ArchProcess {
             command: local_config.command.launch,
             user: Some(username),
+            env: graphics_env,
             log: Some(Arc::new(|it| log::trace!("{}", it))),
         }
         .run();

--- a/src/android/proot/process.rs
+++ b/src/android/proot/process.rs
@@ -22,6 +22,7 @@ const SUPPORT_CHECK_BINARY: &str = "ld-linux-aarch64.so.1";
 pub struct ArchProcess {
     pub command: String,
     pub user: Option<String>,
+    pub env: Vec<(String, String)>,
     pub log: Option<Log>,
 }
 
@@ -165,6 +166,10 @@ impl ArchProcess {
             .arg("TMPDIR=/tmp")
             .arg(format!("USER={}", user))
             .arg(format!("LOGNAME={}", user));
+
+        for (key, value) in self.env {
+            process.arg(format!("{}={}", key, value));
+        }
 
         // user shell
         if user == "root" {

--- a/src/android/proot/setup.rs
+++ b/src/android/proot/setup.rs
@@ -225,6 +225,7 @@ fn install_dependencies(options: &SetupOptions) -> StageOutput {
         ArchProcess {
             command: check.clone(),
             user: None,
+            env: vec![],
             log: None,
         }
         .run()
@@ -245,6 +246,7 @@ fn install_dependencies(options: &SetupOptions) -> StageOutput {
             let output = ArchProcess {
                 command: "rm -f /var/lib/pacman/db.lck".into(),
                 user: None,
+                env: vec![],
                 log: None,
             }
             .run();
@@ -257,6 +259,7 @@ fn install_dependencies(options: &SetupOptions) -> StageOutput {
             ArchProcess {
                 command: install.clone(),
                 user: None,
+                env: vec![],
                 log: Some(Arc::new(move |it| {
                     sender
                         .send(SetupMessage::Progress(it))
@@ -898,7 +901,7 @@ pub fn setup(android_app: AndroidApp) -> PolarBearBackend {
         Box::new(install_dependencies),         // Step 3. Install dependencies
         Box::new(setup_firefox_config),         // Step 4. Setup Firefox config
         Box::new(setup_qterminal_wrapper), // Step 5. Ensure qterminal launches interactive bash
-        Box::new(setup_fake_bwrap),           // Step 6. Replace bwrap with a no-sandbox shim (Android has no user namespaces)
+        Box::new(setup_fake_bwrap), // Step 6. Replace bwrap with a no-sandbox shim (Android has no user namespaces)
         Box::new(setup_onboard_signal_fix), // Step 7. Wrap Onboard to survive proot fstat/signal.set_wakeup_fd failure
         Box::new(setup_lxqt_scaling),       // Step 8. Setup LXQt HiDPI scaling
         Box::new(fix_xkb_symlink),          // Step 9. Fix xkb symlink (last)

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -36,6 +36,9 @@ pub struct LocalConfig {
     /// => So make sure that every config group has a `#[serde(default)]` attribute to avoid invalid sections breaking unrelated parts of the config.
     #[serde(default)]
     pub command: CommandConfig,
+
+    #[serde(default)]
+    pub graphics: GraphicsConfig,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -83,6 +86,46 @@ impl Default for CommandConfig {
             install: default_install(),
             launch: default_launch(),
         }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct GraphicsConfig {
+    #[serde(default)]
+    pub turnip_path: String,
+    #[serde(default)]
+    pub turnip_library_path: String,
+    #[serde(default)]
+    pub turnip_use_zink: bool,
+}
+
+impl GraphicsConfig {
+    pub fn env_vars(&self) -> Vec<(String, String)> {
+        let mut env = Vec::new();
+        let turnip_path = self.turnip_path.trim();
+        let turnip_library_path = self.turnip_library_path.trim();
+
+        if !turnip_path.is_empty() {
+            env.push(("VK_ICD_FILENAMES".to_string(), turnip_path.to_string()));
+            env.push(("VK_DRIVER_FILES".to_string(), turnip_path.to_string()));
+        }
+
+        if !turnip_library_path.is_empty() {
+            env.push((
+                "LD_LIBRARY_PATH".to_string(),
+                format!("{}:/usr/local/lib:/usr/lib", turnip_library_path),
+            ));
+        }
+
+        if self.turnip_use_zink {
+            env.push((
+                "MESA_LOADER_DRIVER_OVERRIDE".to_string(),
+                "zink".to_string(),
+            ));
+            env.push(("GALLIUM_DRIVER".to_string(), "zink".to_string()));
+        }
+
+        env
     }
 }
 
@@ -203,6 +246,7 @@ mod tests {
                 assert_eq!(config.command.check, "check-cmd");
                 assert_eq!(config.command.install, "install-cmd");
                 assert_eq!(config.command.launch, "launch-cmd");
+                assert!(config.graphics.turnip_path.is_empty());
             },
         );
     }
@@ -226,6 +270,37 @@ mod tests {
                 assert_eq!(config.user.username, "testuser");
                 assert_eq!(config.command.check, "try-check");
                 assert_eq!(config.command.install, "install-cmd")
+            },
+        );
+    }
+
+    #[test]
+    fn should_handle_graphics_configs() {
+        with_config_file(
+            r#"
+                [graphics]
+                turnip_path = "/usr/share/vulkan/icd.d/freedreno_icd.aarch64.json"
+                turnip_library_path = "/opt/turnip/lib"
+                turnip_use_zink = true
+            "#,
+            |full_config_path| {
+                let config = parse_config(full_config_path);
+                assert_eq!(
+                    config.graphics.turnip_path,
+                    "/usr/share/vulkan/icd.d/freedreno_icd.aarch64.json"
+                );
+                assert_eq!(config.graphics.turnip_library_path, "/opt/turnip/lib");
+                assert!(config.graphics.turnip_use_zink);
+
+                let env = config.graphics.env_vars();
+                assert!(env.contains(&(
+                    "VK_ICD_FILENAMES".to_string(),
+                    "/usr/share/vulkan/icd.d/freedreno_icd.aarch64.json".to_string()
+                )));
+                assert!(env.contains(&(
+                    "MESA_LOADER_DRIVER_OVERRIDE".to_string(),
+                    "zink".to_string()
+                )));
             },
         );
     }


### PR DESCRIPTION
## Summary
- Add an opt-in `[graphics]` config group for user-supplied Turnip/Mesa Vulkan ICD paths.
- Pass configured Turnip/Mesa environment variables into the PRoot desktop launch environment.
- Document the experimental config and make clear that this does not bundle a driver or replace the Android EGL renderer.

Closes #50.

## Validation
- `cargo fmt --check`
- `cargo test config --lib`
- `cargo check`
- `cargo check --target aarch64-linux-android`

## Notes
This is intentionally an experimental hook. Users still need a compatible Mesa/Turnip build inside the Linux filesystem.