### PR TITLE
[codex] Stabilize LXQt desktop defaults in PRoot

### DIFF
--- a/src/android/proot/setup.rs
+++ b/src/android/proot/setup.rs
@@ -718,6 +718,41 @@ runpy.run_path('/usr/sbin/onboard', run_name='__main__')
     None
 }
 
+fn disable_lxqt_powermanagement(_: &SetupOptions) -> StageOutput {
+    let fs_root = Path::new(ARCH_FS_ROOT);
+    let powermanagement_hidden = r#"[Desktop Entry]
+Type=Application
+Name=LXQt Power Management
+Hidden=true
+"#;
+
+    let mut homes = vec![fs_root.join("root")];
+    if let Ok(entries) = fs::read_dir(fs_root.join("home")) {
+        homes.extend(entries.filter_map(|entry| {
+            let path = entry.ok()?.path();
+            path.is_dir().then_some(path)
+        }));
+    }
+
+    for home in homes {
+        let autostart_dir = home.join(".config/autostart");
+        let _ = fs::create_dir_all(&autostart_dir);
+        fs::write(
+            autostart_dir.join("lxqt-powermanagement.desktop"),
+            powermanagement_hidden,
+        )
+        .expect("Failed to disable lxqt-powermanagement autostart");
+    }
+
+    let system_autostart = fs_root.join("etc/xdg/autostart/lxqt-powermanagement.desktop");
+    if system_autostart.exists() {
+        fs::write(&system_autostart, powermanagement_hidden)
+            .expect("Failed to disable system lxqt-powermanagement autostart");
+    }
+
+    None
+}
+
 fn setup_lxqt_scaling(options: &SetupOptions) -> StageOutput {
     let fs_root = Path::new(ARCH_FS_ROOT);
     let android_app = options.android_app.clone();
@@ -783,19 +818,6 @@ fn setup_lxqt_scaling(options: &SetupOptions) -> StageOutput {
         &[("window_manager", "openbox".to_string())],
     );
     fs::write(&session_path, session_out).expect("Failed to write session.conf");
-
-    // lxqt-powermanagement frequently crashes in a PRoot container due to missing
-    // host power-management interfaces. Disable its autostart by default.
-    let autostart_dir = fs_root.join("root/.config/autostart");
-    let _ = fs::create_dir_all(&autostart_dir);
-    let powermanagement_override = autostart_dir.join("lxqt-powermanagement.desktop");
-    let powermanagement_hidden = r#"[Desktop Entry]
-Type=Application
-Name=LXQt Power Management
-Hidden=true
-"#;
-    fs::write(&powermanagement_override, powermanagement_hidden)
-        .expect("Failed to disable lxqt-powermanagement autostart");
 
     let openbox_user_rc = fs_root.join("root/.config/openbox/rc.xml");
     let openbox_system_rc = fs_root.join("etc/xdg/openbox/rc.xml");
@@ -898,10 +920,11 @@ pub fn setup(android_app: AndroidApp) -> PolarBearBackend {
         Box::new(install_dependencies),         // Step 3. Install dependencies
         Box::new(setup_firefox_config),         // Step 4. Setup Firefox config
         Box::new(setup_qterminal_wrapper), // Step 5. Ensure qterminal launches interactive bash
-        Box::new(setup_fake_bwrap),           // Step 6. Replace bwrap with a no-sandbox shim (Android has no user namespaces)
+        Box::new(setup_fake_bwrap), // Step 6. Replace bwrap with a no-sandbox shim (Android has no user namespaces)
         Box::new(setup_onboard_signal_fix), // Step 7. Wrap Onboard to survive proot fstat/signal.set_wakeup_fd failure
-        Box::new(setup_lxqt_scaling),       // Step 8. Setup LXQt HiDPI scaling
-        Box::new(fix_xkb_symlink),          // Step 9. Fix xkb symlink (last)
+        Box::new(disable_lxqt_powermanagement), // Step 8. Disable LXQt power manager in PRoot
+        Box::new(setup_lxqt_scaling),       // Step 9. Setup LXQt HiDPI scaling
+        Box::new(fix_xkb_symlink),          // Step 10. Fix xkb symlink (last)
     ];
 
     let handle_stage_error = |e: Box<dyn std::any::Any + Send>, sender: &Sender<SetupMessage>| {

--- a/src/android/proot/setup.rs
+++ b/src/android/proot/setup.rs
@@ -19,7 +19,7 @@ use std::{
     fs::{self, File},
     io::{Read, Write},
     os::unix::fs::{symlink, PermissionsExt},
-    path::Path,
+    path::{Path, PathBuf},
     sync::{
         mpsc::{self, Sender},
         Arc, Mutex,
@@ -718,6 +718,44 @@ runpy.run_path('/usr/sbin/onboard', run_name='__main__')
     None
 }
 
+fn user_home_dirs(fs_root: &Path) -> Vec<PathBuf> {
+    let mut homes = vec![fs_root.join("root")];
+    if let Ok(entries) = fs::read_dir(fs_root.join("home")) {
+        homes.extend(entries.filter_map(|entry| {
+            let path = entry.ok()?.path();
+            path.is_dir().then_some(path)
+        }));
+    }
+    homes
+}
+
+fn proot_metadata_path(path: &Path) -> Option<PathBuf> {
+    let file_name = path.file_name()?.to_string_lossy();
+    Some(path.with_file_name(format!(".proot-meta-file.{}.meta", file_name)))
+}
+
+fn write_proot_mode(path: &Path, mode: u32) {
+    fs::set_permissions(path, fs::Permissions::from_mode(mode & 0o777))
+        .expect("Failed to set file permissions");
+
+    if let Some(metadata_path) = proot_metadata_path(path) {
+        let (uid, gid) = fs::read_to_string(&metadata_path)
+            .ok()
+            .and_then(|content| {
+                let mut lines = content.lines();
+                lines.next()?;
+                Some((
+                    lines.next().unwrap_or("0").to_string(),
+                    lines.next().unwrap_or("0").to_string(),
+                ))
+            })
+            .unwrap_or_else(|| ("0".to_string(), "0".to_string()));
+
+        fs::write(&metadata_path, format!("{:o}\n{}\n{}\n", mode, uid, gid))
+            .expect("Failed to write PRoot metadata");
+    }
+}
+
 fn disable_lxqt_powermanagement(_: &SetupOptions) -> StageOutput {
     let fs_root = Path::new(ARCH_FS_ROOT);
     let powermanagement_hidden = r#"[Desktop Entry]
@@ -726,15 +764,7 @@ Name=LXQt Power Management
 Hidden=true
 "#;
 
-    let mut homes = vec![fs_root.join("root")];
-    if let Ok(entries) = fs::read_dir(fs_root.join("home")) {
-        homes.extend(entries.filter_map(|entry| {
-            let path = entry.ok()?.path();
-            path.is_dir().then_some(path)
-        }));
-    }
-
-    for home in homes {
+    for home in user_home_dirs(fs_root) {
         let autostart_dir = home.join(".config/autostart");
         let _ = fs::create_dir_all(&autostart_dir);
         fs::write(
@@ -748,6 +778,136 @@ Hidden=true
     if system_autostart.exists() {
         fs::write(&system_autostart, powermanagement_hidden)
             .expect("Failed to disable system lxqt-powermanagement autostart");
+    }
+
+    None
+}
+
+fn guest_home_path(fs_root: &Path, home: &Path) -> Option<String> {
+    let relative = home.strip_prefix(fs_root).ok()?;
+    Some(format!("/{}", relative.to_string_lossy()))
+}
+
+fn shell_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+fn setup_pcmanfm_lxqt_settings(home: &Path) {
+    let settings_path = home.join(".config/pcmanfm-qt/lxqt/settings.conf");
+    let _ = fs::create_dir_all(
+        settings_path
+            .parent()
+            .expect("Failed to read PCManFM-Qt settings directory"),
+    );
+
+    let content = fs::read_to_string(&settings_path).unwrap_or_default();
+    let content = update_ini_section(&content, "Behavior", &[("QuickExec", "true".to_string())]);
+    let content = update_ini_section(
+        &content,
+        "Desktop",
+        &[("DesktopShortcuts", "Home,Computer,Network".to_string())],
+    );
+    fs::write(&settings_path, content).expect("Failed to write PCManFM-Qt settings");
+}
+
+fn trust_lxqt_desktop_shortcuts(user: Option<String>, guest_paths: &[String]) {
+    let mut commands = Vec::new();
+    for path in guest_paths {
+        for attr in ["metadata::trust", "metadata::trusted"] {
+            commands.push(format!(
+                "gio set -t string {} {} true >/dev/null 2>&1 || true",
+                shell_quote(path),
+                attr
+            ));
+        }
+    }
+
+    let command = format!(
+        "dbus-run-session sh -c {}",
+        shell_quote(&commands.join("; "))
+    );
+    let output = ArchProcess {
+        command,
+        user,
+        log: None,
+    }
+    .run();
+
+    if !output.status.success() {
+        log::warn!(
+            "Failed to trust LXQt desktop shortcuts: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+}
+
+fn setup_lxqt_desktop_shortcuts(_: &SetupOptions) -> StageOutput {
+    let fs_root = Path::new(ARCH_FS_ROOT);
+
+    for home in user_home_dirs(fs_root) {
+        setup_pcmanfm_lxqt_settings(&home);
+
+        let desktop_dir = home.join("Desktop");
+        let _ = fs::create_dir_all(&desktop_dir);
+
+        let home_name = home
+            .file_name()
+            .map(|it| it.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "root".to_string());
+        let guest_home = guest_home_path(fs_root, &home).unwrap_or_else(|| "/root".to_string());
+        let guest_desktop = format!("{}/Desktop", guest_home);
+
+        let entries = [
+            (
+                "computer.desktop",
+                r#"[Desktop Entry]
+Type=Application
+Name=Computer
+Icon=computer
+Exec=pcmanfm-qt computer:///
+Terminal=false
+"#
+                .to_string(),
+            ),
+            (
+                "network.desktop",
+                r#"[Desktop Entry]
+Type=Application
+Name=Network
+Icon=folder-network
+Exec=pcmanfm-qt network:///
+Terminal=false
+"#
+                .to_string(),
+            ),
+            (
+                "user-home.desktop",
+                format!(
+                    r#"[Desktop Entry]
+Type=Application
+Name={}
+Icon=user-home
+Exec=pcmanfm-qt {}
+Terminal=false
+"#,
+                    home_name, guest_home
+                ),
+            ),
+        ];
+
+        for (name, content) in entries {
+            let path = desktop_dir.join(name);
+            fs::write(&path, content).expect("Failed to write LXQt desktop shortcut");
+            write_proot_mode(&path, 0o100755);
+        }
+
+        let guest_paths = [
+            format!("{}/computer.desktop", guest_desktop),
+            format!("{}/network.desktop", guest_desktop),
+            format!("{}/user-home.desktop", guest_desktop),
+        ];
+        let user = (guest_home != "/root").then_some(home_name);
+        trust_lxqt_desktop_shortcuts(user, &guest_paths);
     }
 
     None
@@ -923,8 +1083,9 @@ pub fn setup(android_app: AndroidApp) -> PolarBearBackend {
         Box::new(setup_fake_bwrap), // Step 6. Replace bwrap with a no-sandbox shim (Android has no user namespaces)
         Box::new(setup_onboard_signal_fix), // Step 7. Wrap Onboard to survive proot fstat/signal.set_wakeup_fd failure
         Box::new(disable_lxqt_powermanagement), // Step 8. Disable LXQt power manager in PRoot
-        Box::new(setup_lxqt_scaling),       // Step 9. Setup LXQt HiDPI scaling
-        Box::new(fix_xkb_symlink),          // Step 10. Fix xkb symlink (last)
+        Box::new(setup_lxqt_desktop_shortcuts), // Step 9. Trust default LXQt desktop shortcuts
+        Box::new(setup_lxqt_scaling),       // Step 10. Setup LXQt HiDPI scaling
+        Box::new(fix_xkb_symlink),          // Step 11. Fix xkb symlink (last)
     ];
 
     let handle_stage_error = |e: Box<dyn std::any::Any + Send>, sender: &Sender<SetupMessage>| {

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -62,12 +62,12 @@ pub struct CommandConfig {
 }
 
 fn default_check() -> String {
-    "pacman -Q noto-fonts && pacman -Q lxqt-session && pacman -Q lxqt-panel && pacman -Q pcmanfm-qt && pacman -Q openbox && pacman -Q xorg-xwayland && pacman -Q lxqt-wayland-session && pacman -Q labwc && pacman -Q breeze-icons && pacman -Q qterminal && pacman -Q onboard"
+    "pacman -Q noto-fonts && pacman -Q lxqt-session && pacman -Q lxqt-panel && pacman -Q pcmanfm-qt && pacman -Q gvfs && pacman -Q openbox && pacman -Q xorg-xwayland && pacman -Q lxqt-wayland-session && pacman -Q labwc && pacman -Q breeze-icons && pacman -Q qterminal && pacman -Q onboard"
         .to_string()
 }
 
 fn default_install() -> String {
-    "stdbuf -oL pacman -Syu --needed --noconfirm --noprogressbar noto-fonts liblxqt lxqt-about lxqt-admin lxqt-archiver lxqt-config lxqt-globalkeys lxqt-menu-data lxqt-notificationd lxqt-openssh-askpass lxqt-panel lxqt-policykit lxqt-qtplugin lxqt-runner lxqt-session lxqt-sudo lxqt-themes lxqt-wayland-session pcmanfm-qt qps qterminal screengrab xdg-desktop-portal-lxqt openbox xorg-xwayland labwc breeze-icons onboard"
+    "stdbuf -oL pacman -Syu --needed --noconfirm --noprogressbar noto-fonts liblxqt lxqt-about lxqt-admin lxqt-archiver lxqt-config lxqt-globalkeys lxqt-menu-data lxqt-notificationd lxqt-openssh-askpass lxqt-panel lxqt-policykit lxqt-qtplugin lxqt-runner lxqt-session lxqt-sudo lxqt-themes lxqt-wayland-session pcmanfm-qt gvfs qps qterminal screengrab xdg-desktop-portal-lxqt openbox xorg-xwayland labwc breeze-icons onboard"
         .to_string()
 }
 

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -67,7 +67,7 @@ fn default_check() -> String {
 }
 
 fn default_install() -> String {
-    "stdbuf -oL pacman -Syu --needed --noconfirm --noprogressbar noto-fonts liblxqt lxqt-about lxqt-admin lxqt-archiver lxqt-config lxqt-globalkeys lxqt-menu-data lxqt-notificationd lxqt-openssh-askpass lxqt-panel lxqt-policykit lxqt-powermanagement lxqt-qtplugin lxqt-runner lxqt-session lxqt-sudo lxqt-themes lxqt-wayland-session pcmanfm-qt qps qterminal screengrab xdg-desktop-portal-lxqt openbox xorg-xwayland labwc breeze-icons onboard"
+    "stdbuf -oL pacman -Syu --needed --noconfirm --noprogressbar noto-fonts liblxqt lxqt-about lxqt-admin lxqt-archiver lxqt-config lxqt-globalkeys lxqt-menu-data lxqt-notificationd lxqt-openssh-askpass lxqt-panel lxqt-policykit lxqt-qtplugin lxqt-runner lxqt-session lxqt-sudo lxqt-themes lxqt-wayland-session pcmanfm-qt qps qterminal screengrab xdg-desktop-portal-lxqt openbox xorg-xwayland labwc breeze-icons onboard"
         .to_string()
 }
 


### PR DESCRIPTION
## Summary
- Stop installing `lxqt-powermanagement` and suppress existing LXQt power-manager autostarts so it does not crash inside PRoot.
- Provision LXQt desktop shortcuts for root and existing user homes with executable PRoot metadata and PCManFM trust settings, so Computer/Network/Home launch directly instead of showing the desktop-entry prompt.
- Add `gvfs` to the default LXQt dependency set so PCManFM's Computer and Network locations are backed by GVFS instead of failing with “Operation not supported”.

Closes #143.

## Validation
- `cargo fmt --check`
- `cargo test config --lib`
- `cargo check`
- `cargo check --target aarch64-linux-android`
- `x build --release --platform android --arch arm64 --format apk`
- Installed on the `Pixel_Tablet` AVD; setup installed `gvfs`, the app restarted into LXQt, no `lxqt-powermanagement` process was present, desktop shortcut badges were gone, and double-clicking Computer opened `computer:///` to the File System entry without the Execute File prompt.