### PR TITLE
Improve AdSense page eligibility

### DIFF
--- a/gh-pages/docusaurus.config.ts
+++ b/gh-pages/docusaurus.config.ts
@@ -68,7 +68,12 @@ const config: Config = {
         sitemap: {
           changefreq: "always",
           priority: 0.5,
-          ignorePatterns: ["/tags/**"],
+          ignorePatterns: [
+            "/blog/archive",
+            "/blog/authors",
+            "/blog/tags",
+            "/blog/tags/**",
+          ],
           filename: "sitemap.xml",
         },
       } satisfies Preset.Options,

--- a/gh-pages/src/theme/Layout/index.tsx
+++ b/gh-pages/src/theme/Layout/index.tsx
@@ -12,29 +12,41 @@ const THIN_PAGE_PATHS = new Set([
   "/blog/2025/07/08/thank-you-for-100-github-stars",
   "/blog/2026/04/07/thank-you-new-contributors",
   "/docs/developer/bug-cheat-sheet/android-debug",
+  "/docs/developer/bug-cheat-sheet/egl-context",
   "/docs/developer/bug-cheat-sheet/pacman-progress",
   "/docs/developer/bug-cheat-sheet/random-crashes",
   "/docs/developer/bug-cheat-sheet/xkb-error",
-  "/docs/user/5-android-storage",
+  "/docs/user/android-storage",
   "/docs/user/app-compatibility/gimp",
   "/docs/user/app-compatibility/visual-studio-code",
 ]);
+
+const GENERATED_LISTING_PAGE_PATHS = new Set([
+  "/blog/archive",
+  "/blog/authors",
+  "/blog/tags",
+]);
+
+const GENERATED_LISTING_PAGE_PREFIXES = ["/blog/tags/"];
 
 export default function LayoutWrapper(props: Props): ReactNode {
   const routes = useRouteContext();
   const location = useLocation();
 
   const pathname = location.pathname.replace(/\/$/, "") || "/";
-  const isThinPage = THIN_PAGE_PATHS.has(pathname);
+  const isNoindexPage =
+    THIN_PAGE_PATHS.has(pathname) ||
+    GENERATED_LISTING_PAGE_PATHS.has(pathname) ||
+    GENERATED_LISTING_PAGE_PREFIXES.some((prefix) => pathname.startsWith(prefix));
   const noAdsense =
     (typeof window !== "undefined" && window.self !== window.top) ||
     ["/privacy", "/support-us"].includes(pathname) ||
-    isThinPage ||
+    isNoindexPage ||
     routes.plugin.name === "native";
 
   return (
     <>
-      {isThinPage && (
+      {isNoindexPage && (
         <Head>
           <meta name="robots" content="noindex" />
         </Head>


### PR DESCRIPTION
## Summary

- Add `noindex` and suppress AdSense metadata/scripts for generated blog archive, author, and tag pages.
- Fix the thin-page route list to use Docusaurus' published Android storage URL and add the thin EGL context troubleshooting page.
- Exclude generated blog listing pages from the sitemap.

## Why

AdSense can review pages beyond the signup URL. A few low-original-content pages were still exposed with AdSense metadata, including generated tag/archive pages and a thin doc page whose exclusion used the source filename path instead of its published route.

## Impact

Original guide, docs, blog, and home content can still carry AdSense metadata. Thin/generated pages are now lower-risk because they are marked `noindex`, omitted from the sitemap, and do not load the AdSense script.

## Validation

- `pnpm build`
- Verified built HTML for `/docs/user/android-storage`, `/docs/developer/bug-cheat-sheet/egl-context`, `/blog/tags`, `/blog/archive`, and `/blog/authors` has `noindex` and no AdSense script.
- Verified built sitemap no longer lists the excluded generated/thin URLs.

Note: `pnpm typecheck` still fails on existing Docusaurus/theme typing issues unrelated to this patch.