### PR TITLE
Add actionable graphics and performance diagnostics

### DIFF
--- a/.github/ISSUE_TEMPLATE/performance.yml
+++ b/.github/ISSUE_TEMPLATE/performance.yml
@@ -1,0 +1,123 @@
+name: Performance or graphics problem
+description: Report a reproducible performance, rendering, GPU, or audio problem
+title: "[Performance]: "
+labels: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping improve Local Desktop. Please report one reproducible problem per issue. Separate unrelated touch, installation, package-management, browser, audio, and graphics requests.
+
+  - type: input
+    id: version
+    attributes:
+      label: Local Desktop version
+      placeholder: "For example: 2.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: device
+    attributes:
+      label: Device model
+      placeholder: "Manufacturer and exact model"
+    validations:
+      required: true
+
+  - type: input
+    id: android
+    attributes:
+      label: Android version and build
+      placeholder: "For example: Android 15, build AP3A..."
+    validations:
+      required: true
+
+  - type: input
+    id: soc_gpu
+    attributes:
+      label: SoC and GPU
+      placeholder: "For example: Snapdragon 8 Gen 2 / Adreno 740"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: firmware
+    attributes:
+      label: Device environment
+      options:
+        - Stock, unrooted
+        - Stock, rooted
+        - Custom firmware, unrooted
+        - Custom firmware, rooted
+        - Unknown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: application_type
+    attributes:
+      label: Affected application type
+      multiple: true
+      options:
+        - Native Wayland application
+        - Xwayland/X11 application
+        - Firefox
+        - Entire desktop session
+        - Audio only
+        - Unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction steps
+      description: Provide the smallest reliable sequence that demonstrates the problem.
+      placeholder: |
+        1. Launch ...
+        2. Open ...
+        3. Perform ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behavior
+      description: Include measurable information such as delay, frame rate, CPU usage, or error output where possible.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: report
+    attributes:
+      label: Support report
+      description: Run `sh scripts/localdesktop-support-report.sh` inside the guest, review it for sensitive information, and paste the complete output here.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Add Android logs, screenshots, or application output when available. Do not paste secrets or private data.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Submission checks
+      options:
+        - label: I confirmed that this report describes one primary problem.
+          required: true
+        - label: I searched existing issues for the same device and symptom.
+          required: true
+        - label: I understand that Turnip applies to Qualcomm Adreno GPUs, not Mali or other GPU families.
+          required: true

--- a/gh-pages/docs/developer/graphics-and-performance.md
+++ b/gh-pages/docs/developer/graphics-and-performance.md
@@ -1,0 +1,91 @@
+# Graphics and performance diagnostics
+
+Local Desktop has two distinct graphics layers. Keeping them separate is essential when diagnosing performance or discussing GPU acceleration.
+
+## Host compositor acceleration
+
+The Android application creates an EGL context and uses Smithay's OpenGL ES renderer to composite the desktop into an Android native window. The implementation prefers hardware-accelerated OpenGL ES 3 contexts and falls back to less restrictive configurations when a device or emulator cannot provide the preferred format.
+
+This accelerates the Local Desktop compositor itself. It does **not** automatically provide direct GPU acceleration to Linux applications running inside PRoot.
+
+The compositor already logs the selected OpenGL ES version, vendor, renderer, extensions, and fallback path. Those log lines are useful when determining whether the Android-facing renderer is operating on hardware or software.
+
+## Guest application acceleration
+
+Linux applications run inside a PRoot filesystem while sharing Android's kernel. PRoot is not a virtual machine and does not reserve a separate block of guest RAM. Guest processes use host memory subject to Android's normal process and memory-management policies.
+
+Guest GPU acceleration requires more than installing Mesa packages. A working implementation needs all of the following:
+
+1. A device node and kernel driver that the Android application can access.
+2. A userspace driver compatible with that kernel interface.
+3. A compatible EGL or Vulkan loader.
+4. Correct library, ICD, and environment configuration inside PRoot.
+5. Safe fallback behavior for unsupported devices.
+
+Installing `mesa`, `vulkan-tools`, or an ICD file without the matching Android driver bridge can produce misleading package-level success while applications continue to render on the CPU.
+
+## Turnip and Adreno
+
+Turnip is Mesa's Vulkan driver for Qualcomm Adreno GPUs. It is not a generic Android GPU driver and does not apply to Mali, PowerVR, or other GPU families.
+
+Supporting Turnip inside Local Desktop should therefore be treated as an experimental, device-aware feature rather than a default package installation. At minimum, an implementation must validate:
+
+- Qualcomm/Adreno hardware detection;
+- access to `/dev/kgsl-3d0`;
+- Android Vulkan loader and vendor-library compatibility;
+- Mesa/Turnip build compatibility with the target Android release;
+- operation inside PRoot without weakening application isolation unexpectedly;
+- clean fallback to software rendering when any prerequisite is absent.
+
+Xwayland is not the fundamental blocker. Native Wayland clients and Xwayland clients both require a functional accelerated guest rendering stack before they can avoid software rendering.
+
+## Mali devices
+
+Turnip cannot accelerate Mali GPUs. Mali support depends on the device's kernel interface and a compatible userspace driver, which varies considerably by vendor, Android version, and device firmware. Reports from Mali devices must therefore include the exact device model, Android build, available device nodes, and renderer output rather than assuming that the Qualcomm path applies.
+
+## Collecting a support report
+
+Run the repository utility from inside the Local Desktop Linux environment:
+
+```bash
+sh scripts/localdesktop-support-report.sh > localdesktop-support-report.txt
+```
+
+The script is read-only. It collects:
+
+- session and display environment variables;
+- relevant Android GPU device nodes;
+- installed graphics packages;
+- OpenGL, EGL, Vulkan, Wayland, and PulseAudio diagnostics when their tools are installed;
+- storage mounts;
+- a small CPU and memory snapshot.
+
+Review the report for sensitive information before attaching it to a GitHub issue.
+
+## Interpreting common results
+
+| Result | Meaning |
+| --- | --- |
+| Host log names an Adreno or Mali renderer | The Android-facing compositor is likely using the device GPU. |
+| `glxinfo -B` reports `llvmpipe` | X11 applications inside the guest are software-rendered. |
+| `vulkaninfo` cannot find a physical device | The guest has no functioning Vulkan driver path. |
+| `/dev/kgsl-3d0` is unavailable | A Turnip/Adreno guest path cannot work in its current form. |
+| Audio server is configured but `pactl` cannot connect | Diagnose the host PulseAudio process and TCP endpoint before changing Firefox. |
+| `/android` and `/root/Android` are absent | Android all-files access was not granted or storage binding was not enabled. |
+
+## Filing actionable performance issues
+
+A useful performance report should contain:
+
+- Local Desktop version;
+- device manufacturer and exact model;
+- Android version and build identifier;
+- SoC and GPU family;
+- whether the device is rooted or uses custom firmware;
+- the complete support report;
+- one reproducible workload;
+- observed and expected behavior;
+- whether the problem affects native Wayland applications, Xwayland applications, or both;
+- relevant Android logs when available.
+
+Do not combine unrelated installation, touch-input, browser, audio, package-management, and GPU requests into one optimization issue. Separate reports make regression testing and review substantially more reliable.

--- a/scripts/localdesktop-support-report.sh
+++ b/scripts/localdesktop-support-report.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# Collect a concise Local Desktop support report without modifying the system.
+# Run inside the Local Desktop Arch Linux environment:
+#   sh scripts/localdesktop-support-report.sh
+
+set -u
+
+section() {
+    printf '\n## %s\n' "$1"
+}
+
+run_optional() {
+    label=$1
+    shift
+    printf '\n### %s\n' "$label"
+    if command -v "$1" >/dev/null 2>&1; then
+        "$@" 2>&1 || true
+    else
+        printf '%s is not installed\n' "$1"
+    fi
+}
+
+printf '# Local Desktop support report\n'
+printf 'Generated: '
+date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date
+
+section 'Environment'
+printf 'User: %s\n' "$(id 2>/dev/null || true)"
+printf 'Kernel: %s\n' "$(uname -a 2>/dev/null || true)"
+printf 'Architecture: %s\n' "$(uname -m 2>/dev/null || true)"
+printf 'Desktop: %s\n' "${XDG_CURRENT_DESKTOP:-unset}"
+printf 'Session type: %s\n' "${XDG_SESSION_TYPE:-unset}"
+printf 'Wayland display: %s\n' "${WAYLAND_DISPLAY:-unset}"
+printf 'Display: %s\n' "${DISPLAY:-unset}"
+printf 'Pulse server: %s\n' "${PULSE_SERVER:-unset}"
+printf 'Runtime dir: %s\n' "${XDG_RUNTIME_DIR:-unset}"
+
+section 'Android and device nodes'
+for node in /dev/kgsl-3d0 /dev/dri/renderD128 /dev/dri/card0 /dev/mali0; do
+    if [ -e "$node" ]; then
+        ls -l "$node" 2>&1 || true
+    else
+        printf '%s: unavailable\n' "$node"
+    fi
+done
+
+section 'Installed graphics packages'
+if command -v pacman >/dev/null 2>&1; then
+    pacman -Q 2>/dev/null | grep -Ei '^(mesa|vulkan|libglvnd|wayland|xorg-xwayland|labwc|xfce)' || true
+else
+    printf 'pacman is unavailable\n'
+fi
+
+run_optional 'OpenGL renderer' glxinfo -B
+run_optional 'EGL information' eglinfo -B
+run_optional 'Vulkan summary' vulkaninfo --summary
+run_optional 'Wayland outputs' wlr-randr
+run_optional 'PulseAudio sinks' pactl info
+run_optional 'PulseAudio sink list' pactl list short sinks
+
+section 'Storage mounts'
+mount 2>/dev/null | grep -E '(/android|/root/Android|/sdcard|/dev|/proc|/sys)' || true
+
+section 'Resource snapshot'
+run_optional 'Memory' free -h
+run_optional 'Processes by CPU' ps -eo pid,comm,%cpu,%mem --sort=-%cpu
+
+cat <<'EOF'
+
+## Interpretation notes
+- The Android host compositor and applications inside PRoot are separate graphics layers.
+- A hardware-accelerated host EGL/GLES compositor does not prove that guest applications use the GPU.
+- Turnip is relevant to Qualcomm Adreno Vulkan workloads. It does not accelerate Mali devices.
+- Missing /dev/kgsl-3d0 or a compatible Vulkan loader/ICD means Turnip cannot operate in the guest.
+- Software renderers such as llvmpipe indicate guest-side CPU rendering.
+
+Attach this complete report to the relevant GitHub issue. Remove any information you consider sensitive before posting.
+EOF


### PR DESCRIPTION
## Summary

Add a reproducible diagnostics workflow for graphics, performance, audio, storage, and device-specific support reports.

This change intentionally does **not** claim to enable Turnip or generic guest GPU acceleration. Instead, it establishes the information and terminology required to implement and validate those features safely across different Android GPU stacks.

## Changes

- add `scripts/localdesktop-support-report.sh`, a read-only guest utility that collects:
  - session and display environment details;
  - relevant Android GPU device nodes;
  - installed graphics packages;
  - OpenGL, EGL, Vulkan, Wayland, and PulseAudio diagnostics when available;
  - Android storage mounts;
  - a concise CPU and memory snapshot;
- add a developer guide explaining:
  - host compositor acceleration versus guest application acceleration;
  - why PRoot already shares host memory and is not a VM;
  - the actual prerequisites for Turnip/Adreno support;
  - why Turnip does not apply to Mali devices;
  - how to interpret common diagnostic results;
- add a structured performance issue form requiring one reproducible problem, exact device information, and a complete support report.

## Rationale

The related issues currently combine several independent concerns and use "GPU acceleration" to describe two separate layers:

1. Local Desktop's Android-facing EGL/OpenGL ES compositor; and
2. Linux applications running inside the PRoot guest.

The host compositor already requests hardware-accelerated EGL/GLES contexts. That does not automatically expose Android GPU drivers to guest applications. Installing Mesa or `vulkan-tools` alone therefore cannot provide reliable Turnip acceleration.

A safe Turnip implementation requires Qualcomm/Adreno detection, access to `/dev/kgsl-3d0`, compatible Android Vulkan userspace components, a matching Mesa/Turnip build, correct guest loader/ICD configuration, and a tested software fallback. The diagnostics introduced here make those requirements observable instead of inferred.

## User and developer impact

- reporters can provide device-specific evidence rather than broad optimization requests;
- maintainers can distinguish host EGL failures from guest software rendering;
- Mali reports are no longer conflated with Qualcomm Turnip work;
- future GPU-acceleration patches gain a consistent baseline and acceptance evidence;
- audio and storage symptoms can be triaged from the same report without treating them as graphics failures.

## Validation

- verified the shell utility with `sh -n`;
- verified the issue form as valid YAML;
- reviewed the branch comparison against current upstream-equivalent `main`;
- no runtime behavior is changed by this PR.

## Scope and follow-up

This PR is deliberately diagnostic and documentation-focused. It does not close the hardware-acceleration requests. A follow-up implementation should be experimental and device-gated, with validation on representative Adreno hardware before being enabled by default.

Refs #50
Refs #105
Refs #262
