### PR TITLE
Fix Firefox media decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2250,7 +2250,7 @@ dependencies = [
 
 [[package]]
 name = "localdesktop"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "android-sdkmanager-rs",
  "android_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "localdesktop"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 build = "build.rs"
 default-run = "build_apk"

--- a/src/android/proot/setup.rs
+++ b/src/android/proot/setup.rs
@@ -305,6 +305,7 @@ fn setup_firefox_config(_: &SetupOptions) -> StageOutput {
     // Create autoconfig.js in defaults/pref
     let autoconfig_js = r#"pref("general.config.filename", "localdesktop.cfg");
 pref("general.config.obscure_value", 0);
+pref("general.config.sandbox_enabled", false);
 "#;
 
     let _ = fs::write(format!("{}/autoconfig.js", pref_dir), autoconfig_js)
@@ -314,6 +315,14 @@ pref("general.config.obscure_value", 0);
     let firefox_cfg = r#"// Auto updated by Local Desktop on each startup, do not edit manually
 defaultPref("media.cubeb.sandbox", false);
 defaultPref("security.sandbox.content.level", 0);
+defaultPref("media.allow-audio-non-utility", true);
+defaultPref("media.rdd-process.enabled", false);
+
+try {
+  var { SandboxUtils } = ChromeUtils.importESModule("resource://gre/modules/SandboxUtils.sys.mjs");
+  SandboxUtils.maybeWarnAboutDisabledContentSandbox = () => {};
+  SandboxUtils.observeContentSandboxPref = () => {};
+} catch (_) {}
 "#; // It is required that the first line of this file is a comment, even if you have nothing to comment. Docs: https://support.mozilla.org/en-US/kb/customizing-firefox-using-autoconfig
 
     let _ = fs::write(format!("{}/localdesktop.cfg", firefox_root), firefox_cfg)


### PR DESCRIPTION
- Allow Firefox audio decoding outside the utility process in the proot desktop environment.
- Disable Firefox's RDD media process so decoded video frames are copied in-process instead of failing across the remote decoder path.
- Hide Firefox's disabled-content-sandbox warning notification while keeping the required sandbox level at 0.
- Keeps the change scoped to Firefox autoconfig only.

_Why?_

Firefox fetched media resources correctly and reported H.264/AAC, VP9/Opus, and VP8/Opus support, but remote media decoding failed in proot. Standalone audio needed `media.allow-audio-non-utility`; video reached metadata and then failed with `VideoData::SetVideoDataToImage(...): Failed to copy image data` until the RDD process was disabled.

The visible disabled-sandbox banner comes from Firefox chrome-side `SandboxUtils` when content sandboxing is level 0. Raising the content sandbox level in this proot environment crashed content processes, so this PR suppresses only that notification through AutoConfig.